### PR TITLE
Allow providing cache file to Config parser, enable extending GenericTool

### DIFF
--- a/lib/devpipeline/__init__.py
+++ b/lib/devpipeline/__init__.py
@@ -1,0 +1,8 @@
+import devpipeline.executor
+
+EXECUTOR_TYPES = {
+    "dry-run": executor.DryRunExecutor,
+    "quiet": executor.QuietExecutor,
+    "silent": executor.SilentExecutor,
+    "verbose": executor.VerboseExecutor
+}

--- a/lib/devpipeline/common.py
+++ b/lib/devpipeline/common.py
@@ -121,7 +121,7 @@ class TargetTool(GenericTool):
             self.targets = self.components.sections()
         self.setup(parsed_args)
         if self.verbosity:
-            helper_fn = _EXECUTOR_TYPES.get(parsed_args.executor)
+            helper_fn = EXECUTOR_TYPES.get(parsed_args.executor)
             if not helper_fn:
                 raise Exception(
                     "{} isn't a valid executor".format(parsed_args.executor))

--- a/lib/devpipeline/common.py
+++ b/lib/devpipeline/common.py
@@ -121,7 +121,7 @@ class TargetTool(GenericTool):
             self.targets = self.components.sections()
         self.setup(parsed_args)
         if self.verbosity:
-            helper_fn = EXECUTOR_TYPES.get(parsed_args.executor)
+            helper_fn = devpipeline.EXECUTOR_TYPES.get(parsed_args.executor)
             if not helper_fn:
                 raise Exception(
                     "{} isn't a valid executor".format(parsed_args.executor))
@@ -143,7 +143,7 @@ class TargetTool(GenericTool):
             self.executor.message("  {}".format(target))
             self.executor.message("-" * (4 + len(target)))
             current = self.components[target]
-            env = _create_target_environment(current)
+            env = create_target_environment(current)
 
             config_info["current_target"] = target
             config_info["current_config"] = current

--- a/lib/devpipeline/common.py
+++ b/lib/devpipeline/common.py
@@ -50,14 +50,6 @@ class GenericTool(object):
         pass
 
 
-_EXECUTOR_TYPES = {
-    "dry-run": devpipeline.executor.DryRunExecutor,
-    "quiet": devpipeline.executor.QuietExecutor,
-    "silent": devpipeline.executor.SilentExecutor,
-    "verbose": devpipeline.executor.VerboseExecutor
-}
-
-
 def _set_env(env, key, value):
     real_key = key.upper()
     if value:
@@ -80,7 +72,7 @@ _ENV_SUFFIXES = {
 }
 
 
-def _create_target_environment(target):
+def create_target_environment(target):
     ret = os.environ.copy()
     pattern = re.compile(R"^env(?:_(\w+))?\.(\w+)")
     for key, value in target.items():

--- a/lib/devpipeline/config/config.py
+++ b/lib/devpipeline/config/config.py
@@ -171,7 +171,7 @@ def _is_outdated(cache_file, cache_config):
     return False
 
 
-def update_cache(force=False):
+def update_cache(force=False,cache_file=None):
     """
     Load a build cache, updating it if necessary.
 
@@ -181,7 +181,8 @@ def update_cache(force=False):
     force -- Consider a cache outdated regardless of whether its inputs have
              been modified.
     """
-    cache_file = find_config()
+    if not cache_file:
+        cache_file = find_config()
     cache_config = devpipeline.config.parser.read_config(cache_file)
     if force or _is_outdated(cache_file, cache_config):
         return (process_config(


### PR DESCRIPTION
Config.update_cache() takes a cache_file=<name> param and uses that if provided.  Several changes were required to make GenericTool easier to extend.